### PR TITLE
Remove invalid property value

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoi/eslint-config-core",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Framework agnostic ESLint config maintained by XOi Technologies",
   "repository": {
     "type": "git",

--- a/packages/core/rules/import.js
+++ b/packages/core/rules/import.js
@@ -225,7 +225,6 @@ module.exports = {
     // Reports modules without any exports, or with unused exports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unused-modules.md
     'import/no-unused-modules': ['error', {
-      ignoreExports: [],
       missingExports: true,
       unusedExports: true,
     }],


### PR DESCRIPTION
This fixes the following error when using this eslint config:
```
Error: .eslintrc » @xoi/eslint-config-core » /Users/timyager/code/SPIKES/net-auth-graphql-client/node_modules/@xoi/eslint-config-core/rules/import.js:
	Configuration for rule "import/no-unused-modules" is invalid:
	Value [] should NOT have fewer than 1 items.
```