### PR TITLE
Updated deps of core package since it was updated recently.

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoi/eslint-config-react-native",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "ESLint config for React Native apps by XOi Technologies",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "@xoi/eslint-config-react": "^2.0.5",
+    "@xoi/eslint-config-react": "^2.0.6",
     "eslint-plugin-react-native": "^3.7.0",
     "eslint-plugin-react-native-a11y": "^1.2.0"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoi/eslint-config-react",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "ESLint config for React apps by XOi Technologies",
   "author": "Matt Hamil <mhamil@xoi.io>",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "@xoi/eslint-config-core": "^2.0.3",
+    "@xoi/eslint-config-core": "^2.0.4",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3"
   },


### PR DESCRIPTION
Since `@xoi/eslint-config-core` was updated it was necessary to update the packages that depend on it since the bump fixed an error with how the import rules were configured.